### PR TITLE
Add: Frontend Scripts to automatically retrieve format posts

### DIFF
--- a/public/createPost.html
+++ b/public/createPost.html
@@ -78,14 +78,14 @@
 
             // Retrieves subreaddits.
             $.ajax({
-                url: 'http://localhost:3000/r/allSubreaddits',
+                url: 'http://localhost:3000/r/subreaddits',
                 method: 'get',
                 contentType: "application/json; charset=utf-8",
                 success: function (data, status, xhr) {
+                    data = data.Result;
                     for (var i = 0; i < data.length; i++) {
                         $('#create_post_community').append(`
                             <option id='subreaddit_id_${data[i].subreaddit_id}' value='${data[i].subreaddit_id}'>${data[i].subreaddit_name}</option>
-                    
                         `)
                     }
 

--- a/public/css/color_scheme.css
+++ b/public/css/color_scheme.css
@@ -60,11 +60,11 @@ body {
     background-color: #f8f9fa;
 }
 
-#post1-upvote:hover {
+.post-upvote:hover {
     background-color: #6a5acd35;
 }
 
-#post1-downvote:hover {
+.post-downvote:hover {
     background-color: #6a5acd35;
 }
 
@@ -111,7 +111,4 @@ body {
 .invert-scheme {
     color: white;
     background-color: #734f96;
-}
-
-#add_media_form_button {
 }

--- a/public/r/subreaddit.html
+++ b/public/r/subreaddit.html
@@ -29,7 +29,7 @@
     </div>
     <div class="container-xxl my-md-4">
         <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8" id="post_div">
                 <div class=" bg-white body-borders px-3 py-2 mb-3 rounded shadow-sm">
                     <form>
                         <div class="d-flex">
@@ -55,7 +55,7 @@
                 </div>
 
 
-                <div class="post rounded">
+                <div class="post rounded mb-2">
                     <div class="row g-0">
                         <div class="col-1 upvote-section py-2 justify-content-center">
                             <a class="text-center d-block py-1" id="post1-upvote"><i
@@ -73,7 +73,6 @@
                                 <p class="fw-light text-secondary mx-1">•</p>
                                 <p class="text-secondary" id="post#_time">4 hours ago</p>
                             </div>
-
                             <h5>A really cool post. Lorem Ipsum Dolor sit amet consectetur</h5>
                         </div>
                     </div>
@@ -126,7 +125,7 @@
                 method: 'GET',
                 contentType: "application/json; charset=utf-8",
                 success: function (data, status, xhr) {
-                 
+
                     data = JSON.parse(data);
                     $("#community_name").html(data.subreaddit_name);
                     $("#subreaddit_name").html(data.subreaddit_name);
@@ -139,6 +138,64 @@
                 },
                 error: function (xhr, status, error) {
 
+                }
+            })
+
+            $.ajax({
+                url: `http://localhost:3000/post/get` + pathname,
+                method: 'GET',
+                contentType: "application/json; charset=utf-8",
+                success: function (data, status, xhr) {
+                    console.log(data);
+                    for (var i = 0; i < data.length; i++) {
+
+                        // Calculates Time
+                        var date = new Date(data[i].created_at);
+                        var date_now = new Date();
+                        var hours_between_dates = (date_now - date) / (60 * 60 * 1000);
+                        var days_between_dates = Math.floor((date_now - date) / (60 * 60 * 24 * 1000 ))
+                        var weeks_between_dates = Math.floor((date_now - date) / (60 * 60 * 24 * 7 * 1000))
+
+                        var post_date_output;
+                        if(hours_between_dates < 24) {
+                            post_date_output = `${hours_between_dates} hours ago`
+                        }else if (days_between_dates <= 7) {
+                            post_date_output = `${days_between_dates} days ago`
+                        }else {
+                            post_date_output = `${weeks_between_dates} weeks ago`
+                        }
+                        
+
+                        $('#post_div').append(`
+                        <div class="post rounded mb-2">
+                        <div class="row g-0">
+                        <div class="col-1 upvote-section py-2 justify-content-center">
+                            <a class="text-center d-block py-1 post-upvote" id="post_${data[i].post_id}_upvote"><i
+                                    class="fas fa-arrow-up text-dark"></i></a>
+                            <p id="post#-val" class="text-center mb-0">####</p>
+                            <a class="text-center d-block py-1 post-downvote" id="post_${data[i].post_id}_downvote"><i
+                                    class="fas fa-arrow-down text-dark"></i></a>
+                        </div>
+                        <div class="col-11 bg-white p-2">
+                            <div class="d-flex flex-row align-items-baseline">
+                                <h6 class="d-inline fw-bold clickable-link">r/<a>${data[i].Subreaddit.subreaddit_name}</a></h6>
+                                <p class="fw-light text-secondary mx-1">•</p>
+                                <p class="d-inline text-secondary me-1">Posted by</p>
+                                <p class="d-inline text-secondary clickable-link" id="post_${data[i].User.username}_user"> u/<a>${data[i].User.username}</a></p>
+                                <p class="fw-light text-secondary mx-1">•</p>
+                                <p class="text-secondary" id="post_${data[i].post_id}_time">${post_date_output}</p>
+                            </div>
+
+                            <h5 id="post_${data[i].post_id}_content">${data[i].content}</h5>
+                        </div>
+                        </div>
+                        </div>
+                    `)
+                    }
+
+                },
+                error: function (xhr, status, error) {
+                    console.log(xhr);
                 }
             })
         })


### PR DESCRIPTION
The subreaddit page will now automatically retrieve the posts associated with the subreaddit (incl. the User and Subreaddit foreign keys.)

Example Image of the r/News sureaddit:
![image](https://user-images.githubusercontent.com/87067973/140598119-1ece5023-9d68-404e-ba51-a0cf616b77b9.png)
(the 2nd and 3rd post comes from the database)

The created_at timestamps also show 'hours ago', 'days ago', 'weeks ago' according to how long ago the posts were created.