### PR TITLE
Backend fix recent

### DIFF
--- a/controller/flair.js
+++ b/controller/flair.js
@@ -60,7 +60,6 @@ router.get('/:fk_subreaddit_id', printDebugInfo, (req,res) => {
     })
 })
 
-
 //Add a flair
 router.post('/', printDebugInfo, verify.verifySameUserId, checkModerator, (req,res) => {
 

--- a/model/post.js
+++ b/model/post.js
@@ -97,6 +97,9 @@ var post = {
                     attributes: ['flair_name', 'flair_colour']
                 }
             ],
+            order: [
+                ['created_at', 'DESC'],
+            ],
         }).then(function (result) {
 
             // This block of code calculates the post's popularity


### PR DESCRIPTION
Fixed an issue where recent posts endpoint was returning oldest posts due to missing asc order by:
![image](https://user-images.githubusercontent.com/87083745/142771651-90d7bf6a-6379-4c27-8a97-e38c35b5955b.png)
