### PR TITLE
Fixed: Search Similar Posts not showing the correct number of votes

### DIFF
--- a/public/js/search.js
+++ b/public/js/search.js
@@ -278,7 +278,7 @@ function searchPosts() {
                                     <div class="col-1 upvote-section py-2 justify-content-center">
                                         <a class="text-center d-block py-1" id="post1-upvote"><i
                                                 class="fas fa-arrow-up text-dark"></i></a>
-                                        <p id="post#-val" class="text-center mb-0">6920</p>
+                                        <p id="post#-val" class="text-center mb-0">${similars[i].Post_Votes}</p>
                                         <a class="text-center d-block py-1" id="post1-downvote"><i
                                                 class="fas fa-arrow-down text-dark"></i></a>
                                     </div>


### PR DESCRIPTION
Before fix:
![image](https://user-images.githubusercontent.com/87067973/143538015-452f5cf0-46de-4b82-9789-9c7bbb3c1a14.png)

Fixed Similar posts not showing the correct number of votes beforehand. 

After fix:
![image](https://user-images.githubusercontent.com/87067973/143538052-35fb0092-f052-4e89-8bcc-1cb86d140cc4.png)
